### PR TITLE
Added TYPO3 v11 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "type": "typo3-cms-extension",
   "description": "Allows to display single view on different page than list view and still keep urls user and SEO friendly",
   "require": {
-    "typo3/cms-core": "~9.5.0 || ~10.4.0"
+    "typo3/cms-core": "~9.5.0 || ~10.4.0 || ~11.5.0"
   },
   "authors": [
     {


### PR DESCRIPTION
This PR adds TYPO3 v11 compatibility/ability to install it in v11.

The Extension already worked flawlessly in v11 so I just had to add ~11.5.0 it to the composer.json compatible versions